### PR TITLE
Simplify repo cards and drop README excerpts

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,14 +5,13 @@
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <title>Repos docentes</title>
 <style>
-  body { font-family: system-ui, sans-serif; margin: 0; padding: 1rem; }
+  body { font-family: system-ui, sans-serif; margin: 0; padding: 2rem; background:#f7f7f7; color:#333; }
   header { display:flex; gap:1rem; flex-wrap:wrap; align-items:center; }
   .grid { display:grid; grid-template-columns: repeat(auto-fill,minmax(280px,1fr)); gap:1rem; margin-top:1rem; }
-  .card { border:1px solid #ddd; border-radius:12px; padding:1rem; }
-  .tags, .subjects { display:flex; gap:.5rem; flex-wrap:wrap; margin:.5rem 0; }
-  .chip { border:1px solid #ccc; border-radius:999px; padding:.2rem .6rem; font-size:.85rem; }
+  .card { background:white; border:none; border-radius:12px; padding:1.2rem; box-shadow:0 2px 4px rgba(0,0,0,0.08); display:flex; flex-direction:column; gap:.5rem; }
+  .subjects { display:flex; gap:.5rem; flex-wrap:wrap; margin-top:.5rem; }
   .pill { background:#efefef; border-radius:999px; padding:.2rem .6rem; font-size:.75rem; }
-  .muted { color:#555; font-size:.9rem; }
+  .muted { color:#666; font-size:.9rem; }
   .filters { display:flex; gap:1rem; align-items:center; flex-wrap:wrap; }
   input[type="search"]{ padding:.5rem; width:260px; }
   label { display:flex; gap:.4rem; align-items:center; }
@@ -54,8 +53,7 @@ function match(repo){
   const hay = [
     repo.name, repo.owner, repo.description||"",
     (repo.topics||[]).join(" "),
-    (repo.languages||[]).join(" "),
-    repo.readme_excerpt||""
+    (repo.languages||[]).join(" ")
   ].join(" ").toLowerCase();
   return hay.includes(state.q);
 }
@@ -67,10 +65,7 @@ function card(repo){
     <h3><a href="${repo.url}" target="_blank" rel="noopener">${repo.name}</a></h3>
     <div class="muted">${repo.owner} • ⭐ ${repo.stars} • ${repo.license}</div>
     <p>${repo.description||""}</p>
-    ${repo.readme_excerpt ? `<p class="muted">${repo.readme_excerpt}</p>` : ""}
     <div class="subjects">${subs.map(s=>`<span class="pill">${s}</span>`).join("")}</div>
-    ${repo.topics?.length ? `<div class="tags">${repo.topics.slice(0,6).map(t=>`<span class="chip">#${t}</span>`).join("")}</div>` : ""}
-    ${repo.languages?.length ? `<div class="muted">Lenguajes: ${repo.languages.join(", ")}</div>` : ""}
     <div class="muted">Actualizado: ${new Date(repo.last_update||repo.updated_at).toLocaleDateString()}</div>
   </article>`;
 }

--- a/instalador.sh
+++ b/instalador.sh
@@ -43,7 +43,7 @@ pip install requests
 
 # 5) Crear script Python
 cat > "$SCRIPT_FILE" <<'PYCODE'
-import os, json, base64, requests
+import os, json, requests
 from datetime import datetime
 from time import sleep
 
@@ -74,18 +74,6 @@ def guess_subjects(text, topics):
     blob = f"{(text or '').lower()} {' '.join((topics or [])).lower()}"
     hits = {s for s,kws in SUBJECT_RULES.items() if any(kw in blob for kw in kws)}
     return sorted(hits) or ["projectes"]
-
-def readme_excerpt(owner, repo):
-    url = f"https://api.github.com/repos/{owner}/{repo}/readme"
-    r = requests.get(url, headers=BASE_HEADERS)
-    if r.status_code != 200:
-        return ""
-    content = r.json().get("content")
-    if not content:
-        return ""
-    raw = base64.b64decode(content).decode("utf-8", errors="ignore")
-    words = raw.strip().split()
-    return " ".join(words[:80]) + ("…" if len(words) > 80 else "")
 
 def languages(owner, repo):
     url = f"https://api.github.com/repos/{owner}/{repo}/languages"
@@ -130,9 +118,8 @@ def main():
         meta = fetch_repo(owner, name)
         topics = meta.get("topics", [])
         desc = meta.get("description") or ""
-        excerpt = readme_excerpt(owner, name)
         langs = languages(owner, name)
-        subjects = guess_subjects(desc + " " + excerpt, topics)
+        subjects = guess_subjects(desc, topics)
         data.append({
             "id": f"{owner}/{name}",
             "name": meta["name"],
@@ -144,7 +131,6 @@ def main():
             "stars": meta.get("stargazers_count", 0),
             "last_update": meta.get("pushed_at"),
             "languages": langs,
-            "readme_excerpt": excerpt,
             "subjects": subjects,
             "manual_subjects": [],
             "starred_at": starred_at,
@@ -168,14 +154,13 @@ cat > "$INDEX_FILE" <<'HTML'
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <title>Repos docentes</title>
 <style>
-  body { font-family: system-ui, sans-serif; margin: 0; padding: 1rem; }
+  body { font-family: system-ui, sans-serif; margin: 0; padding: 2rem; background:#f7f7f7; color:#333; }
   header { display:flex; gap:1rem; flex-wrap:wrap; align-items:center; }
   .grid { display:grid; grid-template-columns: repeat(auto-fill,minmax(280px,1fr)); gap:1rem; margin-top:1rem; }
-  .card { border:1px solid #ddd; border-radius:12px; padding:1rem; }
-  .tags, .subjects { display:flex; gap:.5rem; flex-wrap:wrap; margin:.5rem 0; }
-  .chip { border:1px solid #ccc; border-radius:999px; padding:.2rem .6rem; font-size:.85rem; }
+  .card { background:white; border:none; border-radius:12px; padding:1.2rem; box-shadow:0 2px 4px rgba(0,0,0,0.08); display:flex; flex-direction:column; gap:.5rem; }
+  .subjects { display:flex; gap:.5rem; flex-wrap:wrap; margin-top:.5rem; }
   .pill { background:#efefef; border-radius:999px; padding:.2rem .6rem; font-size:.75rem; }
-  .muted { color:#555; font-size:.9rem; }
+  .muted { color:#666; font-size:.9rem; }
   .filters { display:flex; gap:1rem; align-items:center; flex-wrap:wrap; }
   input[type="search"]{ padding:.5rem; width:260px; }
   label { display:flex; gap:.4rem; align-items:center; }
@@ -217,8 +202,7 @@ function match(repo){
   const hay = [
     repo.name, repo.owner, repo.description||"",
     (repo.topics||[]).join(" "),
-    (repo.languages||[]).join(" "),
-    repo.readme_excerpt||""
+    (repo.languages||[]).join(" ")
   ].join(" ").toLowerCase();
   return hay.includes(state.q);
 }
@@ -230,10 +214,7 @@ function card(repo){
     <h3><a href="${repo.url}" target="_blank" rel="noopener">${repo.name}</a></h3>
     <div class="muted">${repo.owner} • ⭐ ${repo.stars} • ${repo.license}</div>
     <p>${repo.description||""}</p>
-    ${repo.readme_excerpt ? `<p class="muted">${repo.readme_excerpt}</p>` : ""}
     <div class="subjects">${subs.map(s=>`<span class="pill">${s}</span>`).join("")}</div>
-    ${repo.topics?.length ? `<div class="tags">${repo.topics.slice(0,6).map(t=>`<span class="chip">#${t}</span>`).join("")}</div>` : ""}
-    ${repo.languages?.length ? `<div class="muted">Lenguajes: ${repo.languages.join(", ")}</div>` : ""}
     <div class="muted">Actualizado: ${new Date(repo.last_update||repo.updated_at).toLocaleDateString()}</div>
   </article>`;
 }


### PR DESCRIPTION
## Summary
- remove README excerpts from index and data ingestion
- use cleaner minimal card design for repositories

## Testing
- `python -m py_compile ingest_starred.py`
- `bash -n instalador.sh`


------
https://chatgpt.com/codex/tasks/task_e_689bb86e372c832c9785b3d5ff8ec755